### PR TITLE
Don't error when <META> is empty

### DIFF
--- a/gemini-diagnostics
+++ b/gemini-diagnostics
@@ -104,6 +104,9 @@ class GeminiResponse:
         self.status, *header_rest = self.header.strip().split(maxsplit=1)
         self.meta = header_rest[0] if header_rest else ''
 
+        if not self.meta:
+            raise Exception("Status should include a <META> line")
+
         if self.status.startswith("2"):
             meta_parts = self.meta.split(";")
             self.mime = meta_parts[0].strip()

--- a/gemini-diagnostics
+++ b/gemini-diagnostics
@@ -101,7 +101,8 @@ class GeminiResponse:
         log("Response header")
         log(f"{self.header!r}", style="info")
 
-        self.status, self.meta = self.header.strip().split(maxsplit=1)
+        self.status, *header_rest = self.header.strip().split(maxsplit=1)
+        self.meta = header_rest[0] if header_rest else ''
 
         if self.status.startswith("2"):
             meta_parts = self.meta.split(";")

--- a/gemini-diagnostics
+++ b/gemini-diagnostics
@@ -102,7 +102,7 @@ class GeminiResponse:
         log(f"{self.header!r}", style="info")
 
         self.status, *header_rest = self.header.strip().split(maxsplit=1)
-        self.meta = header_rest[0] if header_rest else ''
+        self.meta = header_rest[0] if header_rest else ""
 
         if not self.meta:
             raise Exception("Status should include a <META> line")


### PR DESCRIPTION
If my reading is correct, the spec (v0.14.2) doesn't always require the presence of the `<META>` string in the header:

> 3.2.4 4x (TEMPORARY FAILURE)  
> [..] The contents of \<META> **may** provide additional information on the failure, and should be displayed to human users.
> 3.2.5 5x (PERMANENT FAILURE)  
> [..] The contents of \<META> **may** provide additional information on the failure, and should be displayed to human users. [..]

(emphasis mine)

This PR makes it so that the script is able to parse header when it only consists of the status code.

<details><summary>Given this simple Node.js server that always returns 59</summary>

```js
const tls = require('tls');
const fs = require('fs');
const path = require('path');
const options = {
  key: fs.readFileSync(path.join(__dirname, './tls.key')),
  cert: fs.readFileSync(path.join(__dirname, './tls.crt')),
};
const server = tls.createServer(options, (socket) => {
  socket.end('59\r\n');
});
server.listen(1965, () => {
  console.log('listening');
});
```

</details>

Before

```
$ ./gemini-diagnostics --checks URLEmpty
Running server diagnostics check against localhost:1965
...

[URLEmpty] Empty URLs should not be accepted by the server
Request URL
  '\r\n'
Response header
  '59\r\n'
  x not enough values to unpack (expected 2, got 1)

Done!
```

After

```
$ ./gemini-diagnostics --checks URLEmpty
Running server diagnostics check against localhost:1965
...

[URLEmpty] Empty URLs should not be accepted by the server
Request URL
  '\r\n'
Response header
  '59\r\n'
Status should return a failure code (59 BAD REQUEST)
  ✓ Received status of '59'

Done!
```