### PR TITLE
Fix for non-working ipv4/ipv6 check in TLSClaims

### DIFF
--- a/gemini-diagnostics
+++ b/gemini-diagnostics
@@ -141,10 +141,17 @@ class BaseCheck(metaclass=CheckRegistry):
 
     @property
     def netloc(self):
+        host = self.args.host
+        try:
+            ipaddress.IPv6Address(host)
+            host= "[" + host + "]"
+        except ipaddress.AddressValueError:
+            pass
+
         if self.args.port == 1965:
-            return self.args.host
+            return host
         else:
-            return f"{self.args.host}:{self.args.port}"
+            return f"{host}:{self.args.port}"
 
     def resolve_host(self, family):
         host = self.args.host

--- a/gemini-diagnostics
+++ b/gemini-diagnostics
@@ -293,8 +293,8 @@ class TLSClaims(BaseCheck):
                 for ip_address in ext.value.get_values_for_type(
                     cryptography.x509.IPAddress
                 ):
-                    subject_alt_name.append(("IP Address", ip_address))
-
+                    # we need the explicit str here as we might get ipaddress.IPv6Address or ipaddress.IPv4Address which would later on in the ssl.match_hostname cause an rstrip error
+                    subject_alt_name.append(("IP Address", str(ip_address)))
             cert_dict = {
                 "subject": (tuple(subject),),
                 "subjectAltName": tuple(subject_alt_name),


### PR DESCRIPTION
When connecting to a dualstack ipv4/ipv6 server over the ipv4 interface:
./gemini-diagnostics 127.0.0.1 --delay 0 --checks TLSClaims
One will get the following error as the dictionary cert_dict is not correctly assembled.

  {'subject': ((('commonName', 'localhost'),),), 'subjectAltName': (('DNS', 'localhost'), ('IP Address', **IPv4Address**('127.0.0.1')), ('IP Address', **IPv6Address**('::1')))}
  x 'IPv4Address' object has no attribute 'rstrip'

where **IPv4Address** and **IPv6Address** are actually representing class ipaddress.IPv6Address and ipaddress.IPv4Address and therefore fail in ssl.match_hostname  on an rstrip command.

The explicit cast to str fixes the issue.
