### PR TITLE
Added an option "--play-nice" for playing nice with the server (closi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ optional arguments:
   --checks CHECKS  comma separated list of checks to apply
   --show-checks    display the complete list of checks and exit
   --delay DELAY    seconds to sleep between checks (default: 2)
+  --play-nice      do a functionial test or be rude (defautl: 0 rude)"
 ```
 
 ## Supported Tests

--- a/gemini-diagnostics
+++ b/gemini-diagnostics
@@ -188,6 +188,9 @@ class BaseCheck(metaclass=CheckRegistry):
             fp = sock.makefile("rb")
             response = GeminiResponse()
             response.read(fp)
+            if self.args.nice:
+                s = sock.unwrap()
+                s.close()
             return response
 
     def assert_success(self, status):
@@ -255,6 +258,9 @@ class TLSVersion(BaseCheck):
                 log(f"Negotiated {version}", style="warning")
             else:
                 log(f"Negotiated {version}", style="success")
+            if self.args.nice:
+                s = sock.unwrap()
+                s.close()
 
 
 class TLSClaims(BaseCheck):
@@ -391,8 +397,22 @@ class ConcurrentConnections(BaseCheck):
                 log("Opening socket 2", style="info")
                 sock2.sendall(url.encode())
                 log("Closing socket 2", style="info")
+                if self.args.nice:
+                    fp = sock2.makefile("rb")
+                    response = GeminiResponse()
+                    response.read(fp)
+                    s = sock2.unwrap()
+                    s.close()
             sock.sendall(url[1:].encode())
             log("Closing socket 1", style="info")
+
+            if self.args.nice:
+                fp = sock.makefile("rb")
+                response = GeminiResponse()
+                response.read(fp)
+                s = sock.unwrap()
+                s.close()
+
 
         log(f"Concurrent connections supported", style="success")
 
@@ -643,7 +663,7 @@ class URLInvalid(BaseCheck):
 
 
 class URLDotEscape(BaseCheck):
-    """A URL should not be able to escape the root using dot notation"""
+    """An URL should not be able to escape the root using dot notation"""
 
     def check(self):
         url = f"gemini://{self.netloc}/../../\r\n"
@@ -695,6 +715,14 @@ parser.add_argument(
     type=float,
     default=1,
     help="seconds to sleep between checks (default: 1)",
+)
+
+parser.add_argument(
+    "--play-nice",
+    dest = "nice",
+    action="store_true",
+    default=False,
+    help="Do a functionial test or be rude (defautl: 0 rude)",
 )
 # fmt: on
 

--- a/gemini-diagnostics
+++ b/gemini-diagnostics
@@ -16,6 +16,7 @@ import socket
 import ssl
 import sys
 import time
+import _thread
 
 if sys.version_info < (3, 7):
     sys.exit("Fatal Error: script requires Python 3.7+")
@@ -670,6 +671,49 @@ class URLDotEscape(BaseCheck):
         response = self.make_request(url)
         self.assert_permanent_failure(response.status)
 
+class RateLimit(BaseCheck):
+    """Check if a rate limit is in place. Only perfomed with --abuse flag"""
+    def __init__(self, args):
+        super().__init__(args)
+        self.stop = False
+
+    def check(self):
+        if not self.args.abuse:
+            return
+        url = f"gemini://{self.netloc}/\r\n"
+        counter = 0
+        MAX_ROUNDS = 10000
+        while not self.stop:
+            _thread.start_new_thread(self.raceToLimit, (url,))
+            time.sleep(0.001)
+            counter += 1
+            if counter == MAX_ROUNDS:
+                log(f"Rate limit failed", style="failure")
+                return
+        log_test(f"{self.response.status!r}", self.response.status == "44")
+        log(f"Timeout is {self.response.meta} seconds", style="success")
+
+    def raceToLimit(self, url):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+
+
+        address = (self.args.host, self.args.port)
+        with socket.create_connection(address, timeout=5) as sock:
+            with context.wrap_socket(sock, server_hostname=self.args.host) as ssock:
+                    ssock.sendall(url.encode(errors="surrogateescape"))
+                    fp = ssock.makefile("rb")
+                    response = GeminiResponse()
+                    response.read(fp)
+                    if self.args.nice:
+                        s = ssock.unwrap()
+                        s.close()
+
+                    if response.status == "44":
+                        self.response = response
+                        self.stop = True
+                    _thread.exit()
 
 # noinspection PyTypeChecker
 # fmt: off
@@ -724,6 +768,15 @@ parser.add_argument(
     default=False,
     help="Do a functionial test or be rude (defautl: 0 rude)",
 )
+
+parser.add_argument(
+    "--abuse",
+    dest = "abuse",
+    action="store_true",
+    default=False,
+    help="Use Test functions that are clearly abusing the server (default: 0)",
+)
+
 # fmt: on
 
 


### PR DESCRIPTION
I added an option for playing nice with the server. This allows the tester to easier judge, wether the gemini-server is overall working or not. 
I had some trouble with the concurrent connection scenenario. My server accepted all connection and i got green on the test. However, internally (on my side) the concurrent connections did not correctly work. This could have been easier found if the scripts included a "play nice" option and if the connection is not disconnected right away, but rather the reply was checked too.

The functionallity is deactivated by default and can be activated by setting the commandline parameter  --play-nice .
Tests that explicitly test trailing \r\n behavior were not changed.
